### PR TITLE
Adds MIT License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Matt Alexander
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -67,4 +67,7 @@ You will then see something that looks like this:
     pi/2/issue/29711/worklog/14240","author":{"self":"https://myjira.atlassian.net/rest/api/2/user?username=malexan.....
     
     [and on and on...]
-    
+
+# License
+
+MIT © [Matt Alexander](https://github.com/mattalexx)


### PR DESCRIPTION
I don't know if you're still using this, but I'm using it mostly daily. Suggesting [MIT license](https://tldrlegal.com/license/mit-license) as I forked your repo and started doing many changes here and there to fit my needs.

I don't really like php, but your scripts seemed to be the only one working correctly with recent versions of Jira and toggl, so good job! :beers: 